### PR TITLE
Update .gitignore for Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 /captures
 .externalNativeBuild
 .cxx
+.project
+.classpath
+.settings/


### PR DESCRIPTION
I don't personally use Eclipse but see frustration when these are checked into PRs, etc.

Majority if not all contributors won't use Eclipse but it's still quite commonplace for people and I don't see why someone won't avoid opening it in Eclipse considering the other issues I just read, contributions might come from literally anybody.

This ignores what I'm aware of with regular JVM projects; I haven't personally opened an Android, or even Gradle project in Eclipse EVER, and haven't used Eclipse in a long while, so I'm not sure if I missed anything. Perhaps `/gen`?